### PR TITLE
Update FV3 to use MAPL and not submodules

### DIFF
--- a/CubeGridPrototype.F90
+++ b/CubeGridPrototype.F90
@@ -6,8 +6,8 @@ module CubeGridPrototype
 contains
 
   subroutine register_grid_and_regridders()
-    use MAPL_RegridderManagerMod, only: regridder_manager
-    use MAPL_RegridderSpecMod, only: REGRID_METHOD_BILINEAR
+    use MAPL, only: regridder_manager
+    use MAPL, only: REGRID_METHOD_BILINEAR
     use LatLonToCubeRegridderMod
     use CubeToLatLonRegridderMod
     use CubeToCubeRegridderMod


### PR DESCRIPTION
Latest edits from GMAO suggest using just `use MAPL` rather than `use MAPL_...`, and the latter now results in failure. This update is therefore needed to run GCHP with MAPL 2.5.0.