### PR TITLE
Add using dry or total pressure as run-time option

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -336,7 +336,7 @@ contains
       ! -----------------------------------------------------------------
       call MAPL_GetResource(MAPL,                                         &
                             Use_Total_Air_Pressure,                       &
-                            label='Use_Total_Air_Pressure_in_Advection:', &
+                            label='USE_TOTAL_AIR_PRESSURE_IN_ADVECTION:', &
                             default=1,                                    &
                             RC=STATUS )
 

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -337,7 +337,7 @@ contains
       call MAPL_GetResource(MAPL,                                         &
                             Use_Total_Air_Pressure,                       &
                             label='USE_TOTAL_AIR_PRESSURE_IN_ADVECTION:', &
-                            default=1,                                    &
+                            default=0,                                    &
                             RC=STATUS )
 
 


### PR DESCRIPTION
Name: Lizzie Lundgren
Institution: Harvard University

This PR adds dry pressure as a run-time option for advection in GCHP. This option can be toggled with a new entry in config file `GCHP.rc`, called `USE_TOTAL_AIR_PRESSURE_IN_ADVECTION`. The default value is 1 (integer), which means total air pressure will be used if the entry is missing from the config file. Manually setting to a value of 0 (or negative integer) at run-time will turn on dry pressure instead. These updates return the dry pressure functionality which was default in GCHP prior to version 13.4. Total pressure was the only option in versions 13.4 though 14.1, and dry pressure will become the default again in 14.2. 

