### PR TITLE
Export area as REAL8

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -248,6 +248,7 @@ contains
           SHORT_NAME = 'AREA',                                      &
           LONG_NAME  = 'agrid_cell_area',                           &
           UNITS      = 'm+2'  ,                                     &
+          PRECISION  = ESMF_KIND_R8,                                &
           DIMS       = MAPL_DimsHorzOnly,                           &
           VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
      VERIFY_(STATUS)
@@ -514,7 +515,7 @@ contains
       type(ESMF_Config)                  :: CF
       type (MAPL_MetaComp),      pointer :: MAPL
       type (ESMF_VM)                     :: VM
-      real, pointer                      :: temp2d(:,:)
+      real(REAL8), pointer               :: temp2d_r8(:,:) => NULL()
       integer                            :: IS, IE, JS, JE
       logical                            :: gridCreated
       type(ESMF_Grid)                    :: grid
@@ -560,9 +561,10 @@ contains
          IE = FV_Atm(1)%bd%iec
          JS = FV_Atm(1)%bd%jsc
          JE = FV_Atm(1)%bd%jec
-         call MAPL_GetPointer(EXPORT, temp2d, 'AREA', ALLOC=.TRUE., rc=status)
+         call MAPL_GetPointer(EXPORT, temp2d_r8, 'AREA', ALLOC=.TRUE., rc=status)
          VERIFY_(STATUS)
-         temp2d = FV_Atm(1)%gridstruct%area(IS:IE,JS:JE)
+         temp2d_r8 = FV_Atm(1)%gridstruct%area_64(IS:IE,JS:JE)
+         temp2d_r8 => NULL()
       endif
 
       call MAPL_TimerOff(MAPL,"INITIALIZE")


### PR DESCRIPTION
This is a companion PR to https://github.com/geoschem/geos-chem/pull/3050. It updates the area export in offline advection from REAL4 to REAL8. This export is received as an import in GEOS-Chem where it is stored in the `State_Grid` object as double precision floating point. Since it is computed as REAL8 in FV3 we should be exporting it as REAL8 not REAL4.

This PR fixes https://github.com/geoschem/GCHP/issues/514 when merged with the companion GEOS-Chem PR.