### PR TITLE
Scale tracers by pressure ratio in first timestep

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -395,7 +395,7 @@ contains
       ! -----------------------------------------------------------------
       call MAPL_GetResource(MAPL,                                         &
                             Check_Mass_Conservation,                      &
-                            label='CHECK_MASS_CONSERVATION_IN_ADVECTION:', &
+                            label='PRINT_MASS_IN_ADVECTION:', &
                             default=0,                                    &
                             RC=STATUS )
       chk_mass=.FALSE.

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1051,11 +1051,6 @@ contains
 
          endif
 
-#ifdef ADJOINT
-         if (.not. isAdjoint) &
-#endif
-         firstRun=.false.
-
          ! Run FV3 advection
          !------------------
 #ifdef ADJOINT
@@ -1113,10 +1108,6 @@ contains
                                              PLEAdv )
             endif
          endif
-#ifdef ADJOINT
-         if (isAdjoint) &
-              firstRun = .false.
-#endif
 
          ! Update tracer mass conservation
          !-------------------------------------------------------------------
@@ -1261,6 +1252,8 @@ contains
       call MAPL_TimerOff(MAPL,"TOTAL")
 
       !WMP  end if ! AdvCore_Advection
+
+      firstRun=.false.
 
       RETURN_(ESMF_SUCCESS)
 

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1141,7 +1141,6 @@ contains
          endif
 
          if (chk_mass .and. is_master()) then
-#ifdef PRINT_MASS
             write(6,100)  MASS0   , &
                          TMASS0(2), &
                          TMASS0(3), &
@@ -1152,7 +1151,6 @@ contains
                          TMASS1(3), &
                          TMASS1(4), &
                          TMASS1(5)
-#endif
             write(6,103) ( MASS1   - MASS0   )/ MASS0   , &
                          (TMASS1(2)-TMASS0(2))/TMASS0(2), &
                          (TMASS1(3)-TMASS0(3))/TMASS0(3), &

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1569,30 +1569,26 @@ subroutine global_integral_vv (QG,Q,IM,JM,KM)
 
 end subroutine global_integral_vv
 
-subroutine scale_tracers_by_pressure_ratio (Q,DP,PLE,IM,JM,KM,NQ)
+subroutine scale_tracers_by_pressure_ratio (Q,PLE,DP,IM,JM,KM,NQ)
 
-      real(FVPRC), intent(INOUT) :: Q(IM,JM,KM,NQ)
-      real(FVPRC), intent(IN)    :: DP(IM,JM,KM)
-      real(FVPRC), intent(IN)    :: PLE(IM,JM,KM+1)
-      integer,     intent(IN)    :: IM,JM,KM,NQ
+      real(FVPRC), intent(INOUT)       :: Q(IM,JM,KM,NQ)
+      real(FVPRC), intent(IN)          :: PLE(IM,JM,KM+1)
+      real(FVPRC), intent(IN)          :: DP(IM,JM,KM)
+      integer,     intent(IN)          :: IM,JM,KM,NQ
 
       ! Locals
-      integer   :: k,n
-      real(REAL8), allocatable :: dp_current(:,:)
+      integer   :: i,j,k,n
 
-      allocate( dp_current(im,jm) )
-
-      ! Loop over levels and tracers, compute current pressure
-      ! thickness, and apply scaling
-      dp_current = 0.d0
+      ! Loop over levels and tracers and apply scaling
       do n=1,NQ
       do k=1,KM
-         dp_current = PLE(:,:,k+1)-PLE(:,:,k)
-         Q(:,:,k,n) = Q(:,:,k,n) * dp(:,:,k) / dp_current
+      do j=1,JM
+      do i=1,IM
+         Q(i,j,k,n) = Q(i,j,k,n) * dp(i,j,k) / (PLE(i,j,k+1)-PLE(i,j,k))
       enddo
       enddo
-
-      deallocate( dp_current )
+      enddo
+      enddo
 
 end subroutine scale_tracers_by_pressure_ratio
 

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1363,4 +1363,31 @@ subroutine global_integral (QG,Q,PLE,IM,JM,KM,NQ)
 
 end subroutine global_integral
 
+subroutine scale_tracers_by_pressure_ratio (Q,DP,PLE,IM,JM,KM,NQ)
+
+      real(FVPRC), intent(INOUT) :: Q(IM,JM,KM,NQ)
+      real(FVPRC), intent(IN)    :: DP(IM,JM,KM)
+      real(FVPRC), intent(IN)    :: PLE(IM,JM,KM+1)
+      integer,     intent(IN)    :: IM,JM,KM,NQ
+
+      ! Locals
+      integer   :: k,n
+      real(REAL8), allocatable :: dp_current(:,:)
+
+      allocate( dp_current(im,jm) )
+
+      ! Loop over levels and tracers, compute current pressure
+      ! thickness, and apply scaling
+      dp_current = 0.d0
+      do n=1,NQ
+      do k=1,KM
+         dp_current = PLE(:,:,k+1)-PLE(:,:,k)
+         Q(:,:,k,n) = Q(:,:,k,n) * dp(:,:,k) / dp_current
+      enddo
+      enddo
+
+      deallocate( dp_current )
+
+end subroutine scale_tracers_by_pressure_ratio
+
 end module AdvCore_GridCompMod

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -666,6 +666,7 @@ contains
       REAL(FVPRC), POINTER, DIMENSION(:,:,:)   :: DryPLE1 ! GCHP dry
       REAL(FVPRC), POINTER, DIMENSION(:,:,:)   :: PLEAdv  ! GCHP total
       REAL(FVPRC), POINTER, DIMENSION(:,:,:)   :: SPHU0   ! GCHP total
+      REAL(FVPRC), POINTER, DIMENSION(:,:,:)   :: DELPDRY ! import
       REAL(FVPRC), POINTER, DIMENSION(:)       :: AK
       REAL(FVPRC), POINTER, DIMENSION(:)       :: BK
       REAL(REAL8), allocatable :: ak_r8(:),bk_r8(:)
@@ -793,6 +794,12 @@ contains
       MFY    = iMFY
       CX     = iCX
       CY     = iCY
+
+      ! If first run, get import DELPDRY (restart field from GEOS-Chem internal state)
+      if ( firstRun ) THEN
+         call MAPL_GetPointer(IMPORT, iDELPDRY, 'DELPDRY', NotFoundOK=.TRUE., RC=STATUS)
+         VERIFY_(STATUS)
+      endif
 
       ! The quantities to be advected come as friendlies in a bundle
       !  in the import state.
@@ -987,30 +994,32 @@ contains
          ! If first timestep and delta pressure in the restart file is non-zero,
          ! then scale mixing ratios by ratio of restart file delta pressure to
          ! run-time met delta pressure in order to conserve restart file mass
-         if ( firstRun ) THEN
-            call MAPL_GetPointer(IMPORT, iDELPDRY, 'DELPDRY', NotFoundOK=.TRUE., RC=STATUS)
-            VERIFY_(STATUS)
-            if ( associated(iDELPDRY) ) then
-               ! Only scale mixing ratios if non-zero delta pressures in the restart file
-               if ( sum(iDELPDRY) > 0.d0 ) THEN
-                  print *, "ewl: sum of FV3 import DELPDRY : ", sum(iDELPDRY)
-                  print *, "ewl: sum of FV3 export DryPLE0 (surface only) : ", sum(PLE0(:,:,LM+1))
-                  if (AdvCore_Advection>0) then
-                     if (Use_Total_Air_Pressure > 0) then
-                        call scale_tracers_by_pressure_ratio(tracers, PLE0, iDELPDRY, IM, JM, LM, NAdv)
-                     else
-                        call scale_tracers_by_pressure_ratio(tracers, DryPLE0, iDELPDRY, IM, JM, LM, NAdv)
-                     endif
+         if ( firstRun .and. associated(iDELPDRY) ) THEN
+
+            ! Only scale mixing ratios if non-zero delta pressures in the restart file
+            if ( sum(iDELPDRY) > 0.d0 ) THEN
+               ALLOCATE( DELPDRY(IM,JM,LM) )
+               DELPDRY = iDELPDRY
+               if (AdvCore_Advection>0) then
+                  if (Use_Total_Air_Pressure > 0) then
+                     call scale_tracers_by_pressure_ratio(tracers, PLE0, &
+                          DELPDRY, IM, JM, LM, NAdv)
                   else
-                     if (Use_Total_Air_Pressure > 0) then
-                        call scale_tracers_by_pressure_ratio(tracers, PLE1, iDELPDRY, IM, JM, LM, NAdv)
-                     else
-                        call scale_tracers_by_pressure_ratio(tracers, DryPLE1, iDELPDRY, IM, JM, LM, NAdv)
-                     endif
+                     call scale_tracers_by_pressure_ratio(tracers, DryPLE0, &
+                          DELPDRY, IM, JM, LM, NAdv)
                   endif
-                  iDELPDRY => NULL()
+               else
+                  if (Use_Total_Air_Pressure > 0) then
+                     call scale_tracers_by_pressure_ratio(tracers, PLE1, &
+                          DELPDRY, IM, JM, LM, NAdv)
+                  else
+                     call scale_tracers_by_pressure_ratio(tracers, DryPLE1, &
+                          DELPDRY, IM, JM, LM, NAdv)
+                  endif
                endif
+               DEALLOCATE( DELPDRY )
             endif
+
          endif
 
          ! If using total air then set extra tracer to specific humidity and

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -973,6 +973,27 @@ contains
          if ( firstRun ) THEN
             call MAPL_GetPointer(IMPORT, iDELPDRY, 'DELPDRY', NotFoundOK=.TRUE., RC=STATUS)
             VERIFY_(STATUS)
+            if ( associated(iDELPDRY) ) then
+               ! Only scale mixing ratios if non-zero delta pressures in the restart file
+               if ( sum(iDELPDRY) > 0.d0 ) THEN
+                  print *, "ewl: sum of FV3 import DELPDRY : ", sum(iDELPDRY)
+                  print *, "ewl: sum of FV3 export DryPLE0 (surface only) : ", sum(PLE0(:,:,LM+1))
+                  if (AdvCore_Advection>0) then
+                     if (Use_Total_Air_Pressure > 0) then
+                        call scale_tracers_by_pressure_ratio(tracers, PLE0, iDELPDRY, IM, JM, LM, NAdv)
+                     else
+                        call scale_tracers_by_pressure_ratio(tracers, DryPLE0, iDELPDRY, IM, JM, LM, NAdv)
+                     endif
+                  else
+                     if (Use_Total_Air_Pressure > 0) then
+                        call scale_tracers_by_pressure_ratio(tracers, PLE1, iDELPDRY, IM, JM, LM, NAdv)
+                     else
+                        call scale_tracers_by_pressure_ratio(tracers, DryPLE1, iDELPDRY, IM, JM, LM, NAdv)
+                     endif
+                  endif
+                  iDELPDRY => NULL()
+               endif
+            endif
          endif
 
          ! If using total air then set extra tracer to specific humidity and

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1162,25 +1162,14 @@ contains
          endif
 
          if (chk_mass .and. is_master()) then
-            write(6,100)  MASS0   , &
-                         TMASS0(2), &
-                         TMASS0(3), &
-                         TMASS0(4), &
-                         TMASS0(5)
-            write(6,102)  MASS1   , &
-                         TMASS1(2), &
-                         TMASS1(3), &
-                         TMASS1(4), &
-                         TMASS1(5)
+            write(6,100)  MASS0, TMASS0(1)
+            write(6,102)  MASS1, TMASS1(1)
             write(6,103) ( MASS1   - MASS0   )/ MASS0   , &
-                         (TMASS1(2)-TMASS0(2))/TMASS0(2), &
-                         (TMASS1(3)-TMASS0(3))/TMASS0(3), &
-                         (TMASS1(4)-TMASS0(4))/TMASS0(4), &
-                         (TMASS1(5)-TMASS0(5))/TMASS0(5)
- 100        format('Tracer M0  : ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
- 101        format('Tracer Ma  : ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
- 102        format('Tracer M1  : ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
- 103        format('Tracer Mdif: ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
+                         (TMASS1(1)-TMASS0(1))/TMASS0(1)
+ 100        format('Tracer M0  : ',e21.14,' ',e21.14)
+ 101        format('Tracer Ma  : ',e21.14,' ',e21.14)
+ 102        format('Tracer M1  : ',e21.14,' ',e21.14)
+ 103        format('Tracer Mdif: ',e21.14,' ',e21.14)
          endif
 
          ! If using total air pressure then convert all tracers from kg/kg total

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -205,6 +205,15 @@ contains
      VERIFY_(STATUS)
 
     call MAPL_AddImportSpec( gc,                                   &
+        SHORT_NAME = 'DELPDRY',                                    &
+        LONG_NAME  = 'delta dry pressure across levels',           &
+        UNITS      = 'Pa',                                         &
+         PRECISION  = ESMF_KIND_R8,                                &
+         DIMS       = MAPL_DimsHorzVert,                           &
+         VLOCATION  = MAPL_VLocationCenter,             RC=STATUS  )
+     VERIFY_(STATUS)
+
+    call MAPL_AddImportSpec( gc,                                   &
         SHORT_NAME = 'TRADV',                                      &
         LONG_NAME  = 'advected_quantities',                        &
         UNITS      = 'unknown',                                    &
@@ -608,6 +617,7 @@ contains
       type (ESMF_Alarm)             :: ALARM
 
 ! Imports
+      REAL(REAL8), POINTER, DIMENSION(:,:,:)   :: iDELPDRY
       REAL(REAL8), POINTER, DIMENSION(:,:,:)   :: iCX
       REAL(REAL8), POINTER, DIMENSION(:,:,:)   :: iCY
       REAL(REAL8), POINTER, DIMENSION(:,:,:)   :: iMFX
@@ -956,6 +966,14 @@ contains
             end if
 
          end do
+
+         ! If first timestep and delta pressure in the restart file is non-zero,
+         ! then scale mixing ratios by ratio of restart file delta pressure to
+         ! run-time met delta pressure in order to conserve restart file mass
+         if ( firstRun ) THEN
+            call MAPL_GetPointer(IMPORT, iDELPDRY, 'DELPDRY', NotFoundOK=.TRUE., RC=STATUS)
+            VERIFY_(STATUS)
+         endif
 
          ! If using total air then set extra tracer to specific humidity and
          ! convert all other tracers from kg/kg dry to kg/kg total air

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -78,7 +78,7 @@ module AdvCore_GridCompMod
       logical     :: FV3_DynCoreIsRunning=.false.
       integer     :: AdvCore_Advection
       integer     :: Use_Total_Air_Pressure
-      logical     :: chk_mass=.false.
+      logical     :: chk_mass
 #ifdef ADJOINT
       logical                    :: isAdjoint=.false.
       character(len=ESMF_MAXSTR) :: modelPhase
@@ -134,7 +134,7 @@ contains
       type(ESMF_VM)                           :: VM
       integer                                 :: comm, ndt
       integer                                 :: p_split=1
-
+      integer                                 :: Check_Mass_Conservation
 !=============================================================================
 
 ! Begin...
@@ -383,6 +383,16 @@ contains
                             default=0,                                    &
                             RC=STATUS )
 
+      ! Check if printing mass for mass conservation check
+      ! 1 = true; 0 = false
+      ! -----------------------------------------------------------------
+      call MAPL_GetResource(MAPL,                                         &
+                            Check_Mass_Conservation,                      &
+                            label='CHECK_MASS_CONSERVATION_IN_ADVECTION:', &
+                            default=0,                                    &
+                            RC=STATUS )
+      chk_mass=.FALSE.
+      if (Check_Mass_Conservation>0) chk_mass=.TRUE.
 
       ! Start up FMS/MPP
       !-------------------------------------------

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -101,6 +101,13 @@ module AdvCore_GridCompMod
       public SetServices
       logical, allocatable, save :: grids_on_my_pe(:)
 
+      private scale_tracers_by_pressure_ratio
+      private global_integral
+      private global_integral_trmass_from_p
+      private global_integral_trmass_from_dp
+      private global_integral_dp
+      private global_integral_dp_rst
+      private global_integral_vv
 !EOP
 
 !------------------------------------------------------------------------------
@@ -1373,6 +1380,194 @@ subroutine global_integral (QG,Q,PLE,IM,JM,KM,NQ)
       deallocate( qsum1 )
 
 end subroutine global_integral
+
+subroutine global_integral_trmass_from_p (QG,Q,PLE,IM,JM,KM)
+
+      real(FVPRC), intent(OUT)   :: QG
+      real(FVPRC), intent(IN)    :: Q(IM,JM,KM)
+      real(FVPRC), intent(IN)    :: PLE(IM,JM,KM+1)
+      integer,     intent(IN)    :: IM,JM,KM
+
+      ! Locals
+      integer   :: k
+      real(REAL8), allocatable ::    dp(:,:,:)
+      real(FVPRC), allocatable :: qsum1(:,:)
+
+      allocate(    dp(im,jm,km) )
+      allocate( qsum1(im,jm)    )
+
+      ! Pressure thickness [Pa]
+      do k=1,KM
+         dp(:,:,k) = PLE(:,:,k+1)-PLE(:,:,k)
+      enddo
+
+      ! Column sum
+      qsum1(:,:) = 0.d0
+      do k=1,KM
+         qsum1(:,:) = qsum1(:,:) + Q(:,:,k)*dp(:,:,k)
+      enddo
+
+      ! Global sum
+      qg = g_sum( FV_Atm(1)%domain,            &
+           qsum1,                       &
+           is,                          &
+           ie,                          &
+           js,                          &
+           je,                          &
+           FV_Atm(1)%ng,                &
+           FV_Atm(1)%gridstruct%area_64,&
+           0,                           & ! ewl:do not divide total sum by total area at the end
+           .true.)
+
+      deallocate( dp )
+      deallocate( qsum1 )
+
+end subroutine global_integral_trmass_from_p
+
+subroutine global_integral_trmass_from_dp (QG,Q,DP,IM,JM,KM)
+
+      real(FVPRC), intent(OUT)   :: QG
+      real(FVPRC), intent(IN)    :: Q(IM,JM,KM)
+      real(FVPRC), intent(IN)    :: DP(IM,JM,KM)
+      integer,     intent(IN)    :: IM,JM,KM
+
+      ! Locals
+      integer   :: k
+      real(FVPRC), allocatable :: qsum1(:,:)
+
+      allocate( qsum1(im,jm)    )
+
+      ! columm sum (restart file delta pressure is in hPa. convert to Pa here)
+      qsum1(:,:) = 0.d0
+      do k=1,KM
+         qsum1(:,:) = qsum1(:,:) + Q(:,:,k)*dp(:,:,k)*1.d2
+      enddo
+
+      ! global sum
+      qg = g_sum( FV_Atm(1)%domain,            &
+           qsum1,                       &
+           is,                          &
+           ie,                          &
+           js,                          &
+           je,                          &
+           FV_Atm(1)%ng,                &
+           FV_Atm(1)%gridstruct%area_64,&
+           0,                           & ! ewl:do not divide total sum by total area at the end
+           .true.)
+
+      deallocate( qsum1 )
+
+end subroutine global_integral_trmass_from_dp
+
+subroutine global_integral_dp (QG,PLE,IM,JM,KM)
+
+      real(REAL8), intent(OUT)   :: QG
+      real(FVPRC), intent(IN)    :: PLE(IM,JM,KM+1)
+      integer,     intent(IN)    :: IM,JM,KM
+
+      ! Locals
+      integer   :: k,n
+      real(REAL8), allocatable ::    dp(:,:,:)
+      real(FVPRC), allocatable :: qsum1(:,:)
+
+      allocate(    dp(im,jm,km) )
+      allocate( qsum1(im,jm)    )
+
+      ! Pressure thickness [Pa]
+      do k=1,KM
+         dp(:,:,k) = PLE(:,:,k+1)-PLE(:,:,k)
+      enddo
+
+      ! Column sum
+      qsum1(:,:) = 0.d0
+      do k=1,KM
+         qsum1(:,:) = qsum1(:,:) + dp(:,:,k)
+      enddo
+
+      ! Global sum
+      qg = g_sum( FV_Atm(1)%domain,            &
+           qsum1,                       &
+           is,                          &
+           ie,                          &
+           js,                          &
+           je,                          &
+           FV_Atm(1)%ng,                &
+           FV_Atm(1)%gridstruct%area_64,&
+           0,                           & ! ewl: do not divide total sum by total area at the end
+           .true.)
+
+      deallocate( dp )
+      deallocate( qsum1 )
+
+end subroutine global_integral_dp
+
+subroutine global_integral_dp_rst (QG,DP,IM,JM,KM)
+
+      real(REAL8), intent(OUT)   :: QG
+      real(FVPRC), intent(IN)    :: DP(IM,JM,KM)
+      integer,     intent(IN)    :: IM,JM,KM
+
+      ! Locals
+      integer   :: k
+      real(FVPRC), allocatable :: qsum1(:,:)
+
+      allocate( qsum1(im,jm)    )
+
+      ! column sum [Pa]
+      qsum1(:,:) = 0.d0
+      do k=1,KM
+         qsum1(:,:) = qsum1(:,:) + dp(:,:,k)*1.d2
+      enddo
+
+      ! global sum
+      qg = g_sum( FV_Atm(1)%domain,            &
+           qsum1,                       &
+           is,                          &
+           ie,                          &
+           js,                          &
+           je,                          &
+           FV_Atm(1)%ng,                &
+           FV_Atm(1)%gridstruct%area_64,&
+           0,                           & ! ewl: do not divide total sum by total area at the end
+           .true.)
+
+      deallocate( qsum1 )
+
+end subroutine global_integral_dp_rst
+
+subroutine global_integral_vv (QG,Q,IM,JM,KM)
+
+      real(FVPRC), intent(OUT)   :: QG
+      real(FVPRC), intent(IN)    :: Q(IM,JM,KM)
+      integer,     intent(IN)    :: IM,JM,KM
+
+      ! Locals
+      integer   :: k
+      real(FVPRC), allocatable :: qsum1(:,:)
+
+      allocate( qsum1(im,jm)    )
+
+      ! column sum
+      qsum1(:,:) = 0.d0
+      do k=1,KM
+         qsum1(:,:) = qsum1(:,:) + Q(:,:,k)
+      enddo
+
+      ! global sum
+      qg = g_sum( FV_Atm(1)%domain,            &
+           qsum1,                       &
+           is,                          &
+           ie,                          &
+           js,                          &
+           je,                          &
+           FV_Atm(1)%ng,                &
+           FV_Atm(1)%gridstruct%area_64,&
+           0,                           & ! ewl: do not divide total sum by total area at the end
+           .true.)
+
+      deallocate( qsum1 )
+
+end subroutine global_integral_vv
 
 subroutine scale_tracers_by_pressure_ratio (Q,DP,PLE,IM,JM,KM,NQ)
 

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1437,10 +1437,10 @@ subroutine global_integral_trmass_from_dp (QG,Q,DP,IM,JM,KM)
 
       allocate( qsum1(im,jm)    )
 
-      ! columm sum (restart file delta pressure is in hPa. convert to Pa here)
+      ! columm sum
       qsum1(:,:) = 0.d0
       do k=1,KM
-         qsum1(:,:) = qsum1(:,:) + Q(:,:,k)*dp(:,:,k)*1.d2
+         qsum1(:,:) = qsum1(:,:) + Q(:,:,k)*dp(:,:,k)
       enddo
 
       ! global sum
@@ -1516,7 +1516,7 @@ subroutine global_integral_dp_rst (QG,DP,IM,JM,KM)
       ! column sum [Pa]
       qsum1(:,:) = 0.d0
       do k=1,KM
-         qsum1(:,:) = qsum1(:,:) + dp(:,:,k)*1.d2
+         qsum1(:,:) = qsum1(:,:) + dp(:,:,k)
       enddo
 
       ! global sum

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -672,6 +672,8 @@ contains
       REAL(REAL8), allocatable :: ak_r8(:),bk_r8(:)
       REAL(FVPRC), POINTER, DIMENSION(:,:,:,:) :: TRACERS
       REAL(FVPRC) :: MASS1, TMASS1(ntracers)
+      REAL(FVPRC) :: spc1_vv, spc1_mass_dp_met, spc1_mass_dp_rst ! debug
+      REAL(FVPRC) :: dp_met, dp_rst                              ! debug
       TYPE(AdvCoreTracers), POINTER :: advTracers(:)
       type(ESMF_FieldBundle) :: TRADV
       type(ESMF_Field)       :: field
@@ -991,6 +993,42 @@ contains
 
          end do
 
+         !----------------------------------------------------------
+         ! Optional pre-scaling debug : Sum area-weighted
+         ! values and print (first run only)
+         !----------------------------------------------------------
+         !if (chk_mass .and. firstRun) then
+         !   dP_rst=0.d0
+         !   spc1_mass_dp_rst=0.d0
+         !
+         !   ! Delta pressure from the restart file
+         !   if ( ASSOCIATED(iDELPDRY) ) &
+         !        call global_integral_dp_rst(dp_rst, iDELPDRY, IM,JM,LM)
+         !
+         !   ! Delta pressure as computed from met
+         !   call global_integral_dp(dp_met, DryPLE0, IM,JM,LM)
+         !
+         !   ! v/v for species 1
+         !   call global_integral_vv(spc1_vv, Tracers(:,:,:,1), IM,JM,LM)
+         !
+         !   ! Species 1 v/v * dp (rst) (proxy for mass in restart file)
+         !   if ( ASSOCIATED(iDELPDRY) ) &
+         !        call global_integral_trmass_from_dp(spc1_mass_dp_rst, &
+         !        Tracers(:,:,:,1), iDELPDRY, IM,JM,LM)
+         !
+         !   ! Species 1 v/v * dp (met) (dp computed in function)
+         !   call global_integral_trmass_from_p(spc1_mass_dp_met, &
+         !        Tracers(:,:,:,1), DryPLE0, IM,JM,LM)
+         !
+         !   if (is_master()) then
+         !      write(6,*) "Global area-weighted sums: dp met, dp rst, spc1 vv, spc1 vv*dp_met, spc1 vv*dp_rst"
+         !      write(6,100)  dp_met, dp_rst, spc1_vv, &
+         !           spc1_mass_dp_met, spc1_mass_dp_rst
+         !   endif
+100       format('First run, before scaling: ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
+         !
+         !endif ! chk_mass .and. firstRun
+
          ! If first timestep and delta pressure in the restart file is non-zero,
          ! then scale mixing ratios by ratio of restart file delta pressure to
          ! run-time met delta pressure in order to conserve restart file mass
@@ -1098,6 +1136,40 @@ contains
                if (MASS0 /= 0.0) TMASS0=TMASS0/MASS0
             endif
 
+            !----------------------------------------------------------
+            ! Optional pre-advection debug : Sum additional
+            ! area-weighted values and print (first run only)
+            !----------------------------------------------------------
+            !dP_rst=0.d0
+            !spc1_mass_dp_rst=0.d0
+            !
+            !! Delta pressure from the restart file
+            !if ( ASSOCIATED(iDELPDRY) ) &
+            !     call global_integral_dp_rst(dp_rst, iDELPDRY, IM,JM,LM)
+            !
+            !! Delta pressure as computed from met
+            !call global_integral_dp(dp_met, DryPLE0, IM,JM,LM)
+            !
+            !! v/v for species 1
+            !call global_integral_vv(spc1_vv, Tracers(:,:,:,1), IM,JM,LM)
+            !
+            !! Species 1 v/v * dp (rst) (proxy for mass in restart file)
+            !if ( ASSOCIATED(iDELPDRY) ) &
+            !     call global_integral_trmass_from_dp(spc1_mass_dp_rst, &
+            !     Tracers(:,:,:,1), iDELPDRY, IM,JM,LM)
+            !
+            !! Species 1 v/v * dp (met) (dp computed in function)
+            !call global_integral_trmass_from_p(spc1_mass_dp_met, &
+            !     Tracers(:,:,:,1), DryPLE0, IM,JM,LM)
+            !
+            !! Print the values
+            !if (is_master()) then
+            !   write(6,*) "Global area-weighted sums: sfc p met, dp met, dp rst, spc1 vv, spc1 vv*dp_met, spc1 vv*dp_rst"
+            !   write(6,101)  MASS0, dp_met, dp_rst, spc1_vv, &
+            !        spc1_mass_dp_met, spc1_mass_dp_rst
+            !endif
+101         format('First run, after scaling: ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14,' ',e21.14)
+            !----------------------------------------------------------
 
          endif ! chk_mass .and. firstRun
 
@@ -1200,6 +1272,20 @@ contains
 103            format('Tracer M1  : ',e21.14,' ',e21.14)
 104            format('Tracer Mdif: ',e21.14,' ',e21.14)
             endif
+
+            ! Optional post-advection debug : Sum additional values and print
+            !! Area-weighted delta pressure
+            !call global_integral_dp(dp_met, DryPLE1, IM,JM,LM)
+            !
+            !! Area-weighted species v/v * dp using met (proxy mass)
+            !call global_integral_trmass_from_p(spc1_mass_dp_met, &
+            !     Tracers(:,:,:,1), DryPLE1, IM,JM,LM)
+            !
+            !if (is_master()) then
+            !   write(6,*) "Global area-weighted sums: sfc p met, spc1 vv*dp_met"
+            !   write(6,105) dp_met, spc1_mass_dp_met
+            !endif
+105         format('Post-advection: ',e21.14,' ',e21.14)
 
          endif ! chk_mass
 
@@ -1430,7 +1516,7 @@ subroutine global_integral_trmass_from_p (QG,Q,PLE,IM,JM,KM)
            je,                          &
            FV_Atm(1)%ng,                &
            FV_Atm(1)%gridstruct%area_64,&
-           0,                           & ! ewl:do not divide total sum by total area at the end
+           0,                           & ! do not divide total sum by total aread
            .true.)
 
       deallocate( dp )
@@ -1466,7 +1552,7 @@ subroutine global_integral_trmass_from_dp (QG,Q,DP,IM,JM,KM)
            je,                          &
            FV_Atm(1)%ng,                &
            FV_Atm(1)%gridstruct%area_64,&
-           0,                           & ! ewl:do not divide total sum by total area at the end
+           0,                           & ! do not divide total sum by total area
            .true.)
 
       deallocate( qsum1 )
@@ -1507,7 +1593,7 @@ subroutine global_integral_dp (QG,PLE,IM,JM,KM)
            je,                          &
            FV_Atm(1)%ng,                &
            FV_Atm(1)%gridstruct%area_64,&
-           0,                           & ! ewl: do not divide total sum by total area at the end
+           0,                           & ! do not divide total sum by total area
            .true.)
 
       deallocate( dp )
@@ -1542,7 +1628,7 @@ subroutine global_integral_dp_rst (QG,DP,IM,JM,KM)
            je,                          &
            FV_Atm(1)%ng,                &
            FV_Atm(1)%gridstruct%area_64,&
-           0,                           & ! ewl: do not divide total sum by total area at the end
+           0,                           & ! do not divide total sum by total area
            .true.)
 
       deallocate( qsum1 )
@@ -1576,7 +1662,7 @@ subroutine global_integral_vv (QG,Q,IM,JM,KM)
            je,                          &
            FV_Atm(1)%ng,                &
            FV_Atm(1)%gridstruct%area_64,&
-           0,                           & ! ewl: do not divide total sum by total area at the end
+           0,                           & ! do not divide total sum by total area
            .true.)
 
       deallocate( qsum1 )

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -93,7 +93,7 @@ module AdvCore_GridCompMod
       character(len=ESMF_MAXSTR) :: myTracer
       character(len=ESMF_MAXSTR) :: tMassStr
       real(FVPRC), SAVE          :: TMASS0(ntracers)
-      real(REAL8), SAVE          ::  MASS0
+      real(REAL8), SAVE          :: MASS0
       logical    , SAVE          :: firstRun=.true.
 
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -1036,67 +1036,70 @@ contains
          end if
 
          ! Check Mass conservation
-         if (chk_mass) then
+         if (chk_mass .and. firstRun) then
 
-            ! Compute mass differently based on whether advection on or off,
-            ! and whether using total or dry air pressure
-            if (firstRun .and. AdvCore_Advection>0) then
+            ! Compute initial mass (proxy). Do this differently based on
+            ! whether advection, on or off and whether using total or dry
+            ! air pressure in advection. Mass of first run is saved for
+            ! comparison in all subsequent timesteps.
+            if (AdvCore_Advection>0) then
                if ( Use_Total_Air_Pressure > 0 ) then
                   MASS0 = g_sum( FV_Atm(1)%domain,            &
-                                 PLE0(:,:,LM),                &
-                                 is,                          &
-                                 ie,                          &
-                                 js,                          &
-                                 je,                          &
-                                 FV_Atm(1)%ng,                &
-                                 FV_Atm(1)%gridstruct%area_64,&
-                                 1,                           &
-                                 .true. )
+                       PLE0(:,:,LM),                &
+                       is,                          &
+                       ie,                          &
+                       js,                          &
+                       je,                          &
+                       FV_Atm(1)%ng,                &
+                       FV_Atm(1)%gridstruct%area_64,&
+                       1,                           &
+                       .true. )
                   call global_integral(TMASS0, TRACERS, PLE0, IM,JM,LM,NAdv)
                else
                   MASS0 = g_sum( FV_Atm(1)%domain,            &
-                                 DryPLE0(:,:,LM),             &
-                                 is,                          &
-                                 ie,                          &
-                                 js,                          &
-                                 je,                          &
-                                 FV_Atm(1)%ng,                &
-                                 FV_Atm(1)%gridstruct%area_64,&
-                                 1,                           &
-                                 .true. )
+                       DryPLE0(:,:,LM),             &
+                       is,                          &
+                       ie,                          &
+                       js,                          &
+                       je,                          &
+                       FV_Atm(1)%ng,                &
+                       FV_Atm(1)%gridstruct%area_64,&
+                       1,                           &
+                       .true. )
                   call global_integral(TMASS0, TRACERS, DryPLE0, IM,JM,LM,NAdv)
+                  if (MASS0 /= 0.0) TMASS0=TMASS0/MASS0
                endif
-               if (MASS0 /= 0.0) TMASS0=TMASS0/MASS0
-            elseif (firstRun) then
+            else
                if ( Use_Total_Air_Pressure > 0 ) then
                   MASS0 = g_sum( FV_Atm(1)%domain,            &
-                                 PLE1(:,:,LM),                &
-                                 is,                          &
-                                 ie,                          &
-                                 js,                          &
-                                 je,                          &
-                                 FV_Atm(1)%ng,                &
-                                 FV_Atm(1)%gridstruct%area_64,&
-                                 1,                           &
-                                 .true. )
+                       PLE1(:,:,LM),                &
+                       is,                          &
+                       ie,                          &
+                       js,                          &
+                       je,                          &
+                       FV_Atm(1)%ng,                &
+                       FV_Atm(1)%gridstruct%area_64,&
+                       1,                           &
+                       .true. )
                   call global_integral(TMASS0, TRACERS, PLE1, IM,JM,LM,NAdv)
                else
                   MASS0 = g_sum( FV_Atm(1)%domain,            &
-                                 DryPLE1(:,:,LM),             &
-                                 is,                          &
-                                 ie,                          &
-                                 js,                          &
-                                 je,                          &
-                                 FV_Atm(1)%ng,                &
-                                 FV_Atm(1)%gridstruct%area_64,&
-                                 1,                           &
-                                .true.)
+                       DryPLE1(:,:,LM),             &
+                       is,                          &
+                       ie,                          &
+                       js,                          &
+                       je,                          &
+                       FV_Atm(1)%ng,                &
+                       FV_Atm(1)%gridstruct%area_64,&
+                       1,                           &
+                       .true.)
                   call global_integral(TMASS0, TRACERS, DryPLE1, IM,JM,LM,NQ)
                endif
                if (MASS0 /= 0.0) TMASS0=TMASS0/MASS0
             endif
 
-         endif
+
+         endif ! chk_mass .and. firstRun
 
          ! Run FV3 advection
          !------------------
@@ -1156,7 +1159,9 @@ contains
             endif
          endif
 
-         ! Update tracer mass conservation
+         ! Compute tracer mass post-advection (proxy). Done for all timesteps.
+         ! Note that TMASS0 and MASS0 refer to proxy mass of first timestep and are
+         ! printed and diffed every timestep for comparison.
          !-------------------------------------------------------------------
          if (chk_mass) then
             if ( Use_Total_Air_Pressure > 0 ) then
@@ -1185,18 +1190,18 @@ contains
                call global_integral(TMASS1, TRACERS, DryPLE1, IM,JM,LM,NQ)
             endif
             if (MASS1 /= 0.0) TMASS1=TMASS1/MASS1
-         endif
 
-         if (chk_mass .and. is_master()) then
-            write(6,100)  MASS0, TMASS0(1)
-            write(6,102)  MASS1, TMASS1(1)
-            write(6,103) ( MASS1   - MASS0   )/ MASS0   , &
-                         (TMASS1(1)-TMASS0(1))/TMASS0(1)
- 100        format('Tracer M0  : ',e21.14,' ',e21.14)
- 101        format('Tracer Ma  : ',e21.14,' ',e21.14)
- 102        format('Tracer M1  : ',e21.14,' ',e21.14)
- 103        format('Tracer Mdif: ',e21.14,' ',e21.14)
-         endif
+            if (is_master()) then
+               write(6,102)  MASS0, TMASS0(1)
+               write(6,103)  MASS1, TMASS1(1)
+               write(6,104) ( MASS1   - MASS0   )/ MASS0   , &
+                    (TMASS1(1)-TMASS0(1))/TMASS0(1)
+102            format('Tracer M0  : ',e21.14,' ',e21.14)
+103            format('Tracer M1  : ',e21.14,' ',e21.14)
+104            format('Tracer Mdif: ',e21.14,' ',e21.14)
+            endif
+
+         endif ! chk_mass
 
          ! If using total air pressure then convert all tracers from kg/kg total
          ! to kg/kg dry for use in GEOS-Chem. Use the post-advection specific


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR makes the following changes:
1. Adds import DELPDRY which is the GEOS-Chem restart file field DELP_DRY
2. Adds new subroutine to scale tracers by ratio of import delta pressure from GEOS-Chem (ultimately from restart file) and delta pressure computed from import meteorology
3. Applies scaling in the first timestep only, prior to the call to offline advection, so that species mass in restart file is conserved
4. Removes compiler option PRINT_MASS which was not implemented into GCHP
5. Adds config file option (in GCHP.rc) to turn on printing global mass proxy in advection, for investigating mass conservation
6. Adds option debug prints, and associated subroutines for global mass sums, within the mass print blocks that can be uncommented for mass conservation debugging

**This PR must be merged at the same time as two companion PRs:**
https://github.com/geoschem/geos-chem/pull/3062
https://github.com/geoschem/GCHP/pull/515

### Expected changes

This update results in small differences in all species in all GCHP simulations. GEOS-Chem Classic is not affected.

### Reference(s)

None

### Related Github Issue

Closes https://github.com/geoschem/geos-chem/issues/2536

