### PR TITLE
Allow optional ctmEnv-only mode in GCHP

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -211,7 +211,9 @@ contains
          VLOCATION  = MAPL_VLocationEdge,             RC=STATUS  )
      VERIFY_(STATUS)
 
-    call MAPL_AddImportSpec( gc,                                   &
+#ifndef MODEL_CTMENV
+     ! Only include this if not running CTMenv-only since DELPDRY comes from GEOS-Chem
+     call MAPL_AddImportSpec( gc,                                  &
         SHORT_NAME = 'DELPDRY',                                    &
         LONG_NAME  = 'delta dry pressure across levels',           &
         UNITS      = 'Pa',                                         &
@@ -219,6 +221,7 @@ contains
          DIMS       = MAPL_DimsHorzVert,                           &
          VLOCATION  = MAPL_VLocationCenter,             RC=STATUS  )
      VERIFY_(STATUS)
+#endif
 
     call MAPL_AddImportSpec( gc,                                   &
         SHORT_NAME = 'TRADV',                                      &

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ if (CRAY_POINTER)
   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${CRAY_POINTER})
 endif()
 
+# GCHP: option to skip advection run
+if (MODEL_CTMENV)
+  add_definitions (-DMODEL_CTMENV)
+endif()
+
 add_definitions (-DSPMD -DMAPL_MODE)
 
 foreach(flag ${tmp})


### PR DESCRIPTION
This pull request adds the `MODEL_CTMENV` option for GCHP which skips advection and GEOS-Chem when running. The only update needed in this repository is blocking off the DELPDRY import, since it comes from GEOS-Chem. Note that while advection is turned off in the ctmEnv-only option, the code is still compiled, which is why the DELPDRY import cannot be declared. The MAPL connection to GEOS-Chem does not exist in ctmEnv-only mode.

This PR must be merged at the same time as:

- https://github.com/geoschem/geos-chem/pull/2742
- https://github.com/geoschem/GCHP/pull/477

